### PR TITLE
Improve Win32k process/thread attaching

### DIFF
--- a/NtDOOM/entry.c
+++ b/NtDOOM/entry.c
@@ -353,50 +353,49 @@ VOID DoomGetTime(INT* sec, INT* usec) {
 
 // Kill me
 VOID DoomProcessKeys(NT_USER_GET_KEY_STATE Function) {
-	NT_USER_GET_KEY_STATE NtUserGetKeyState = Function;
-	if (NtUserGetKeyState(VK_RETURN) & 0x8000)
+	if (Function(VK_RETURN) & 0x8000)
 		doom_key_down(DOOM_KEY_ENTER);
-	if (!(NtUserGetKeyState(VK_RETURN) & 0x8000))
+	if (!(Function(VK_RETURN) & 0x8000))
 		doom_key_up(DOOM_KEY_ENTER);
 
-	if (NtUserGetKeyState(VK_LEFT) & 0x8000)
+	if (Function(VK_LEFT) & 0x8000)
 		doom_key_down(DOOM_KEY_LEFT_ARROW);
-	if (!(NtUserGetKeyState(VK_LEFT) & 0x8000))
+	if (!(Function(VK_LEFT) & 0x8000))
 		doom_key_up(DOOM_KEY_LEFT_ARROW);
 
-	if (NtUserGetKeyState(VK_RIGHT) & 0x8000)
+	if (Function(VK_RIGHT) & 0x8000)
 		doom_key_down(DOOM_KEY_RIGHT_ARROW);
-	if (!(NtUserGetKeyState(VK_RIGHT) & 0x8000))
+	if (!(Function(VK_RIGHT) & 0x8000))
 		doom_key_up(DOOM_KEY_RIGHT_ARROW);
 
-	if (NtUserGetKeyState(VK_UP) & 0x8000)
+	if (Function(VK_UP) & 0x8000)
 		doom_key_down(DOOM_KEY_UP_ARROW);
-	if (!(NtUserGetKeyState(VK_UP) & 0x8000))
+	if (!(Function(VK_UP) & 0x8000))
 		doom_key_up(DOOM_KEY_UP_ARROW);
 
-	if (NtUserGetKeyState(VK_DOWN) & 0x8000)
+	if (Function(VK_DOWN) & 0x8000)
 		doom_key_down(DOOM_KEY_DOWN_ARROW);
-	if (!(NtUserGetKeyState(VK_DOWN) & 0x8000))
+	if (!(Function(VK_DOWN) & 0x8000))
 		doom_key_up(DOOM_KEY_DOWN_ARROW);
 
-	if (NtUserGetKeyState(VK_SPACE) & 0x8000)
+	if (Function(VK_SPACE) & 0x8000)
 		doom_key_down(DOOM_KEY_SPACE);
-	if (!(NtUserGetKeyState(VK_SPACE) & 0x8000))
+	if (!(Function(VK_SPACE) & 0x8000))
 		doom_key_up(DOOM_KEY_SPACE);
 
-	if (NtUserGetKeyState(VK_CONTROL) & 0x8000)
+	if (Function(VK_CONTROL) & 0x8000)
 		doom_key_down(DOOM_KEY_CTRL);
-	if (!(NtUserGetKeyState(VK_CONTROL) & 0x8000))
+	if (!(Function(VK_CONTROL) & 0x8000))
 		doom_key_up(DOOM_KEY_CTRL);
 
-	if (NtUserGetKeyState(VK_ESCAPE) & 0x8000)
+	if (Function(VK_ESCAPE) & 0x8000)
 		doom_key_down(DOOM_KEY_ESCAPE);
-	if (!(NtUserGetKeyState(VK_ESCAPE) & 0x8000))
+	if (!(Function(VK_ESCAPE) & 0x8000))
 		doom_key_up(DOOM_KEY_ESCAPE);
 
-	if (NtUserGetKeyState('Y') & 0x8000)
+	if (Function('Y') & 0x8000)
 		doom_key_down(DOOM_KEY_Y);
-	if (!(NtUserGetKeyState('Y') & 0x8000))
+	if (!(Function('Y') & 0x8000))
 		doom_key_up(DOOM_KEY_Y);
 }
 

--- a/NtDOOM/entry.c
+++ b/NtDOOM/entry.c
@@ -295,7 +295,7 @@ VOID DoomExit(INT code) {
 
 #define DRIVE_ROOT "X:\\"
 
-VOID DoomGetEnv(CHAR* Name) {
+char* DoomGetEnv(CHAR* Name) {
 	if (!strcmp(Name, "HOME"))
 		return DRIVE_ROOT;
 	return NULL;

--- a/NtDOOM/types.h
+++ b/NtDOOM/types.h
@@ -417,6 +417,33 @@ typedef struct _SYSTEM_PROCESS_INFORMATION {
 	SYSTEM_THREAD_INFORMATION Threads[1];
 } SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
 
+typedef enum _KAPC_ENVIRONMENT {
+	OriginalApcEnvironment,
+	AttachedApcEnvironment,
+	CurrentApcEnvironment,
+	InsertApcEnvironment
+} KAPC_ENVIRONMENT, *PKAPC_ENVIRONMENT;
+
+typedef VOID(NTAPI *PKNORMAL_ROUTINE)(
+	_In_ PVOID NormalContext,
+	_In_ PVOID SystemArgument1,
+	_In_ PVOID SystemArgument2
+	);
+
+typedef VOID KKERNEL_ROUTINE(
+	_In_ PRKAPC Apc,
+	_Inout_ PKNORMAL_ROUTINE *NormalRoutine,
+	_Inout_ PVOID *NormalContext,
+	_Inout_ PVOID *SystemArgument1,
+	_Inout_ PVOID *SystemArgument2
+	);
+
+typedef KKERNEL_ROUTINE(NTAPI *PKKERNEL_ROUTINE);
+
+typedef VOID(NTAPI *PKRUNDOWN_ROUTINE)(
+	_In_ PRKAPC Apc
+	);
+
 
 NTKERNELAPI PVOID RtlFindExportedRoutineByName(PVOID DllBase, PCHAR RoutineName);
 
@@ -472,4 +499,28 @@ PVOID
 NTAPI
 PsGetThreadWin32Thread(
 	_In_ PETHREAD Thread
+	);
+
+NTKERNELAPI
+VOID
+NTAPI
+KeInitializeApc(
+	_Out_ PRKAPC Apc,
+	_In_ PRKTHREAD Thread,
+	_In_ KAPC_ENVIRONMENT Environment,
+	_In_ PKKERNEL_ROUTINE KernelRoutine,
+	_In_opt_ PKRUNDOWN_ROUTINE RundownRoutine,
+	_In_opt_ PKNORMAL_ROUTINE NormalRoutine,
+	_In_opt_ KPROCESSOR_MODE ProcessorMode,
+	_In_opt_ PVOID NormalContext
+	);
+
+NTKERNELAPI
+BOOLEAN
+NTAPI
+KeInsertQueueApc(
+	_Inout_ PRKAPC Apc,
+	_In_opt_ PVOID SystemArgument1,
+	_In_opt_ PVOID SystemArgument2,
+	_In_ KPRIORITY Increment
 	);

--- a/NtDOOM/types.h
+++ b/NtDOOM/types.h
@@ -123,4 +123,353 @@ typedef struct _LDR_DATA_TABLE_ENTRY {
 	ULONG TimeDateStamp;
 } LDR_DATA_TABLE_ENTRY, * PLDR_DATA_TABLE_ENTRY;
 
-PVOID RtlFindExportedRoutineByName(PVOID DllBase, PCHAR RoutineName);
+typedef enum _SYSTEM_INFORMATION_CLASS {
+	SystemBasicInformation,
+	SystemProcessorInformation,
+	SystemPerformanceInformation,
+	SystemTimeOfDayInformation,
+	SystemPathInformation,
+	SystemProcessInformation,
+	SystemCallCountInformation,
+	SystemDeviceInformation,
+	SystemProcessorPerformanceInformation,
+	SystemFlagsInformation,
+	SystemCallTimeInformation,
+	SystemModuleInformation,
+	SystemLocksInformation,
+	SystemStackTraceInformation,
+	SystemPagedPoolInformation,
+	SystemNonPagedPoolInformation,
+	SystemHandleInformation,
+	SystemObjectInformation,
+	SystemPageFileInformation,
+	SystemVdmInstemulInformation,
+	SystemVdmBopInformation,
+	SystemFileCacheInformation,
+	SystemPoolTagInformation,
+	SystemInterruptInformation,
+	SystemDpcBehaviorInformation,
+	SystemFullMemoryInformation,
+	SystemLoadGdiDriverInformation,
+	SystemUnloadGdiDriverInformation,
+	SystemTimeAdjustmentInformation,
+	SystemSummaryMemoryInformation,
+	SystemMirrorMemoryInformation,
+	SystemPerformanceTraceInformation,
+	SystemObsolete0,
+	SystemExceptionInformation,
+	SystemCrashDumpStateInformation,
+	SystemKernelDebuggerInformation,
+	SystemContextSwitchInformation,
+	SystemRegistryQuotaInformation,
+	SystemExtendServiceTableInformation,
+	SystemPrioritySeperation,
+	SystemVerifierAddDriverInformation,
+	SystemVerifierRemoveDriverInformation,
+	SystemProcessorIdleInformation,
+	SystemLegacyDriverInformation,
+	SystemCurrentTimeZoneInformation,
+	SystemLookasideInformation,
+	SystemTimeSlipNotification,
+	SystemSessionCreate,
+	SystemSessionDetach,
+	SystemSessionInformation,
+	SystemRangeStartInformation,
+	SystemVerifierInformation,
+	SystemVerifierThunkExtend,
+	SystemSessionProcessInformation,
+	SystemLoadGdiDriverInSystemSpace,
+	SystemNumaProcessorMap,
+	SystemPrefetcherInformation,
+	SystemExtendedProcessInformation,
+	SystemRecommendedSharedDataAlignment,
+	SystemComPlusPackage,
+	SystemNumaAvailableMemory,
+	SystemProcessorPowerInformation,
+	SystemEmulationBasicInformation,
+	SystemEmulationProcessorInformation,
+	SystemExtendedHandleInformation,
+	SystemLostDelayedWriteInformation,
+	SystemBigPoolInformation,
+	SystemSessionPoolTagInformation,
+	SystemSessionMappedViewInformation,
+	SystemHotpatchInformation,
+	SystemObjectSecurityMode,
+	SystemWatchdogTimerHandler,
+	SystemWatchdogTimerInformation,
+	SystemLogicalProcessorInformation,
+	SystemWow64SharedInformationObsolete,
+	SystemRegisterFirmwareTableInformationHandler,
+	SystemFirmwareTableInformation,
+	SystemModuleInformationEx,
+	SystemVerifierTriageInformation,
+	SystemSuperfetchInformation,
+	SystemMemoryListInformation,
+	SystemFileCacheInformationEx,
+	SystemThreadPriorityClientIdInformation,
+	SystemProcessorIdleCycleTimeInformation,
+	SystemVerifierCancellationInformation,
+	SystemProcessorPowerInformationEx,
+	SystemRefTraceInformation,
+	SystemSpecialPoolInformation,
+	SystemProcessIdInformation,
+	SystemErrorPortInformation,
+	SystemBootEnvironmentInformation,
+	SystemHypervisorInformation,
+	SystemVerifierInformationEx,
+	SystemTimeZoneInformation,
+	SystemImageFileExecutionOptionsInformation,
+	SystemCoverageInformation,
+	SystemPrefetchPatchInformation,
+	SystemVerifierFaultsInformation,
+	SystemSystemPartitionInformation,
+	SystemSystemDiskInformation,
+	SystemProcessorPerformanceDistribution,
+	SystemNumaProximityNodeInformation,
+	SystemDynamicTimeZoneInformation,
+	SystemCodeIntegrityInformation,
+	SystemProcessorMicrocodeUpdateInformation,
+	SystemProcessorBrandString,
+	SystemVirtualAddressInformation,
+	SystemLogicalProcessorAndGroupInformation,
+	SystemProcessorCycleTimeInformation,
+	SystemStoreInformation,
+	SystemRegistryAppendString,
+	SystemAitSamplingValue,
+	SystemVhdBootInformation,
+	SystemCpuQuotaInformation,
+	SystemNativeBasicInformation,
+	SystemErrorPortTimeouts,
+	SystemLowPriorityIoInformation,
+	SystemTpmBootEntropyInformation,
+	SystemVerifierCountersInformation,
+	SystemPagedPoolInformationEx,
+	SystemSystemPtesInformationEx,
+	SystemNodeDistanceInformation,
+	SystemAcpiAuditInformation,
+	SystemBasicPerformanceInformation,
+	SystemQueryPerformanceCounterInformation,
+	SystemSessionBigPoolInformation,
+	SystemBootGraphicsInformation,
+	SystemScrubPhysicalMemoryInformation,
+	SystemBadPageInformation,
+	SystemProcessorProfileControlArea,
+	SystemCombinePhysicalMemoryInformation,
+	SystemEntropyInterruptTimingInformation,
+	SystemConsoleInformation,
+	SystemPlatformBinaryInformation,
+	SystemPolicyInformation,
+	SystemHypervisorProcessorCountInformation,
+	SystemDeviceDataInformation,
+	SystemDeviceDataEnumerationInformation,
+	SystemMemoryTopologyInformation,
+	SystemMemoryChannelInformation,
+	SystemBootLogoInformation,
+	SystemProcessorPerformanceInformationEx,
+	SystemCriticalProcessErrorLogInformation,
+	SystemSecureBootPolicyInformation,
+	SystemPageFileInformationEx,
+	SystemSecureBootInformation,
+	SystemEntropyInterruptTimingRawInformation,
+	SystemPortableWorkspaceEfiLauncherInformation,
+	SystemFullProcessInformation,
+	SystemKernelDebuggerInformationEx,
+	SystemBootMetadataInformation,
+	SystemSoftRebootInformation,
+	SystemElamCertificateInformation,
+	SystemOfflineDumpConfigInformation,
+	SystemProcessorFeaturesInformation,
+	SystemRegistryReconciliationInformation,
+	SystemEdidInformation,
+	SystemManufacturingInformation,
+	SystemEnergyEstimationConfigInformation,
+	SystemHypervisorDetailInformation,
+	SystemProcessorCycleStatsInformation,
+	SystemVmGenerationCountInformation,
+	SystemTrustedPlatformModuleInformation,
+	SystemKernelDebuggerFlags,
+	SystemCodeIntegrityPolicyInformation,
+	SystemIsolatedUserModeInformation,
+	SystemHardwareSecurityTestInterfaceResultsInformation,
+	SystemSingleModuleInformation,
+	SystemAllowedCpuSetsInformation,
+	SystemVsmProtectionInformation,
+	SystemInterruptCpuSetsInformation,
+	SystemSecureBootPolicyFullInformation,
+	SystemCodeIntegrityPolicyFullInformation,
+	SystemAffinitizedInterruptProcessorInformation,
+	SystemRootSiloInformation,
+	SystemCpuSetInformation,
+	SystemCpuSetTagInformation,
+	SystemWin32WerStartCallout,
+	SystemSecureKernelProfileInformation,
+	SystemCodeIntegrityPlatformManifestInformation,
+	SystemInterruptSteeringInformation,
+	SystemSupportedProcessorArchitectures,
+	SystemMemoryUsageInformation,
+	SystemCodeIntegrityCertificateInformation,
+	SystemPhysicalMemoryInformation,
+	SystemControlFlowTransition,
+	SystemKernelDebuggingAllowed,
+	SystemActivityModerationExeState,
+	SystemActivityModerationUserSettings,
+	SystemCodeIntegrityPoliciesFullInformation,
+	SystemCodeIntegrityUnlockInformation,
+	SystemIntegrityQuotaInformation,
+	SystemFlushInformation,
+	SystemProcessorIdleMaskInformation,
+	SystemSecureDumpEncryptionInformation,
+	SystemWriteConstraintInformation,
+	SystemKernelVaShadowInformation,
+	SystemHypervisorSharedPageInformation,
+	SystemFirmwareBootPerformanceInformation,
+	SystemCodeIntegrityVerificationInformation,
+	SystemFirmwarePartitionInformation,
+	SystemSpeculationControlInformation,
+	SystemDmaGuardPolicyInformation,
+	SystemEnclaveLaunchControlInformation,
+	SystemWorkloadAllowedCpuSetsInformation,
+	SystemCodeIntegrityUnlockModeInformation,
+	SystemLeapSecondInformation,
+	SystemFlags2Information,
+	SystemSecurityModelInformation,
+	SystemCodeIntegritySyntheticCacheInformation,
+	SystemFeatureConfigurationInformation,
+	SystemFeatureConfigurationSectionInformation,
+	SystemFeatureUsageSubscriptionInformation,
+	SystemSecureSpeculationControlInformation,
+	SystemSpacesBootInformation,
+	SystemFwRamdiskInformation,
+	SystemWheaIpmiHardwareInformation,
+	SystemDifSetRuleClassInformation,
+	SystemDifClearRuleClassInformation,
+	SystemDifApplyPluginVerificationOnDriver,
+	SystemDifRemovePluginVerificationOnDriver,
+	SystemShadowStackInformation,
+	SystemBuildVersionInformation,
+	SystemPoolLimitInformation,
+	SystemCodeIntegrityAddDynamicStore,
+	SystemCodeIntegrityClearDynamicStores,
+	SystemDifPoolTrackingInformation,
+	SystemPoolZeroingInformation,
+	SystemDpcWatchdogInformation,
+	SystemDpcWatchdogInformation2,
+	SystemSupportedProcessorArchitectures2,
+	SystemSingleProcessorRelationshipInformation,
+	SystemXfgCheckFailureInformation,
+	SystemIommuStateInformation,
+	SystemHypervisorMinrootInformation,
+	SystemHypervisorBootPagesInformation,
+	SystemPointerAuthInformation,
+	SystemSecureKernelDebuggerInformation,
+	SystemOriginalImageFeatureInformation,
+	MaxSystemInfoClass
+} SYSTEM_INFORMATION_CLASS;
+
+typedef struct _SYSTEM_THREAD_INFORMATION {
+	LARGE_INTEGER KernelTime;
+	LARGE_INTEGER UserTime;
+	LARGE_INTEGER CreateTime;
+	ULONG WaitTime;
+	PVOID StartAddress;
+	CLIENT_ID ClientId;
+	KPRIORITY Priority;
+	LONG BasePriority;
+	ULONG ContextSwitches;
+	ULONG ThreadState;
+	KWAIT_REASON WaitReason;
+} SYSTEM_THREAD_INFORMATION, *PSYSTEM_THREAD_INFORMATION;
+
+typedef struct _SYSTEM_PROCESS_INFORMATION {
+	ULONG NextEntryOffset;
+	ULONG NumberOfThreads;
+	LARGE_INTEGER SpareLi1;
+	LARGE_INTEGER SpareLi2;
+	LARGE_INTEGER SpareLi3;
+	LARGE_INTEGER CreateTime;
+	LARGE_INTEGER UserTime;
+	LARGE_INTEGER KernelTime;
+	UNICODE_STRING ImageName;
+	KPRIORITY BasePriority;
+	HANDLE UniqueProcessId;
+	HANDLE InheritedFromUniqueProcessId;
+	ULONG HandleCount;
+	ULONG SessionId;
+	ULONG_PTR PageDirectoryBase;
+	SIZE_T PeakVirtualSize;
+	SIZE_T VirtualSize;
+	ULONG PageFaultCount;
+	SIZE_T PeakWorkingSetSize;
+	SIZE_T WorkingSetSize;
+	SIZE_T QuotaPeakPagedPoolUsage;
+	SIZE_T QuotaPagedPoolUsage;
+	SIZE_T QuotaPeakNonPagedPoolUsage;
+	SIZE_T QuotaNonPagedPoolUsage;
+	SIZE_T PagefileUsage;
+	SIZE_T PeakPagefileUsage;
+	SIZE_T PrivatePageCount;
+	LARGE_INTEGER ReadOperationCount;
+	LARGE_INTEGER WriteOperationCount;
+	LARGE_INTEGER OtherOperationCount;
+	LARGE_INTEGER ReadTransferCount;
+	LARGE_INTEGER WriteTransferCount;
+	LARGE_INTEGER OtherTransferCount;
+	SYSTEM_THREAD_INFORMATION Threads[1];
+} SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
+
+
+NTKERNELAPI PVOID RtlFindExportedRoutineByName(PVOID DllBase, PCHAR RoutineName);
+
+NTSYSCALLAPI
+NTSTATUS
+NTAPI
+ZwQuerySystemInformation(
+	_In_ SYSTEM_INFORMATION_CLASS SystemInformationClass,
+	_Out_opt_ PVOID SystemInformation,
+	_In_ ULONG SystemInformationLength,
+	_Out_opt_ PULONG ReturnLength
+	);
+
+NTKERNELAPI
+NTSTATUS
+NTAPI
+PsLookupProcessThreadByCid(
+	_In_ PCLIENT_ID Cid,
+	_Outptr_opt_ PEPROCESS *Process,
+	_Out_opt_ PETHREAD *Thread
+	);
+
+NTKERNELAPI
+NTSTATUS
+NTAPI
+PsAcquireProcessExitSynchronization(
+	_In_ PEPROCESS Process
+	);
+
+NTKERNELAPI
+VOID
+NTAPI
+PsReleaseProcessExitSynchronization(
+	_In_ PEPROCESS Process
+	);
+
+NTKERNELAPI
+ULONG
+NTAPI
+PsGetProcessSessionIdEx(
+	_In_ PEPROCESS Process
+	);
+
+NTKERNELAPI
+PVOID
+NTAPI
+PsGetProcessWin32Process(
+	_In_ PEPROCESS Process
+	);
+
+NTKERNELAPI
+PVOID
+NTAPI
+PsGetThreadWin32Thread(
+	_In_ PETHREAD Thread
+	);


### PR DESCRIPTION
This is a great game, but unfortunately I was seeing quite a few bugchecks when trying to play this, even on Windows 11 22621. Most of these were due to attempts to access a nonexistent/bogus Win32 thread in `NtUserGetKeyState`.

This PR attempts to fix some of the "early access experience" in two parts, by:
1. Rewriting the problematic `GetThreadByProcessName` and `SpoofWin32Thread` functions using NT APIs instead.
2. Moving the game loop from `DriverEntry` to an APC routine which is queued to the target thread.